### PR TITLE
feat: check for existing `node_modules` folder && `package.json`

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -69,6 +69,24 @@ module.exports.check = function(request) {
   return dep;
 };
 
+module.exports.checkNodeModules = function checkNodeModules() {
+   try {
+    var stats = fs.lstatSync(path.join(process.cwd(), "node_modules"));
+
+    if (stats.isDirectory()) {
+      return;
+    }
+  } catch(e) { }
+
+  var pkgPath = require.resolve(path.join(process.cwd(), "package.json"));
+  var pkg = require(pkgPath);
+
+  if (!pkg.dependencies && !pkg.devDependencies) return;
+
+  console.info("Installing modules from `%s`...", "package.json");
+  spawn.sync("npm", ["install"], { stdio: "inherit" });
+};
+
 module.exports.checkBabel = function checkBabel() {
   try {
     var babelrc = require.resolve(path.join(process.cwd(), ".babelrc"));

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -32,6 +32,7 @@ function NpmInstallPlugin(options) {
   this.resolving = {};
 
   installer.checkPackage();
+  installer.checkNodeModules();
   installer.checkBabel();
 }
 

--- a/test/mock/empty_package_json/package.json
+++ b/test/mock/empty_package_json/package.json
@@ -1,0 +1,4 @@
+{
+  "name": "empty_package_json",
+  "version": "1.0.0"
+}

--- a/test/mock/noneempty_package_json/package.json
+++ b/test/mock/noneempty_package_json/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "noneempty_package_json",
+  "version": "1.0.0",
+  "dependencies": {
+    "react": "15.4.1"
+  }
+}

--- a/test/plugin.test.js
+++ b/test/plugin.test.js
@@ -12,6 +12,7 @@ describe("plugin", function() {
 
     this.checkBabel = expect.spyOn(installer, "checkBabel");
     this.checkPackage = expect.spyOn(installer, "checkPackage");
+    this.checkNodeModules = expect.spyOn(installer, "checkNodeModules");
 
     this.compiler = {
       options: {},
@@ -44,6 +45,7 @@ describe("plugin", function() {
   afterEach(function() {
     this.check.restore();
     this.checkBabel.restore();
+    this.checkNodeModules.restore();
     this.checkPackage.restore();
     this.install.restore();
     this.next.restore();
@@ -51,6 +53,10 @@ describe("plugin", function() {
 
   it("should checkBabel", function() {
     expect(this.checkBabel).toHaveBeenCalled();
+  });
+
+  it("should checkNodeModules", function() {
+    expect(this.checkNodeModules).toHaveBeenCalled();
   });
 
   it("should checkPackage", function() {


### PR DESCRIPTION
Hi,

I'm working on a tool for fast prototyping called [Aik](/d4rkr00t/aik) and I use this awesome plugin. Thank you for your effort.

But let's jump to the point of proposed changes:

This plugin perfectly covers use case when you start something from scratch, when you don't even have a package.json file or any modules installed. But for the case when you, for example, checked out some repo which already contains a package.json non of the dependencies will be installed. Because of this check here [installer.js#L42](https://github.com/ericclemmons/npm-install-webpack-plugin/blob/23af5551f35fdd22bae8afe45f716452361a168e/src/installer.js#L42). 

What this PR changes is that it adds additional step which checks if there is a package.json and there isn't node_modules dir then it runs `npm install`. So for tools like [Aik](/d4rkr00t/aik) users may just use `aik index.js` as they expect and node modules will be installed automatically.


