### PR TITLE
Give webpack a shot at resolving loaders first

### DIFF
--- a/example/webpack2/.babelrc
+++ b/example/webpack2/.babelrc
@@ -4,7 +4,7 @@
   ],
   "presets": [
     "react",
-    "es2015-webpack",
+    ["es2015", {"modules": false}],
     "stage-0"
   ],
   "env": {

--- a/example/webpack2/package.json
+++ b/example/webpack2/package.json
@@ -2,7 +2,7 @@
   "private": true,
   "devDependencies": {
     "reload-server-webpack-plugin": "1.0.1",
-    "webpack": "2.1.0-beta.6"
+    "webpack": "2.2.0"
   },
   "scripts": {
     "link": "(cd .. && npm link .) && npm link npm-install-webpack-plugin",

--- a/example/webpack2/src/client.js
+++ b/example/webpack2/src/client.js
@@ -2,6 +2,6 @@
 import App from "App";
 
 // Testing inline-loaders
-import loadRender from "bundle?lazy!./render";
+import loadRender from "bundle-loader?lazy!./render";
 
 loadRender(({ render }) => render(App));

--- a/example/webpack2/webpack.config.client.js
+++ b/example/webpack2/webpack.config.client.js
@@ -12,7 +12,7 @@ module.exports = Object.assign({}, defaults, {
   },
 
   output: Object.assign({}, defaults.output, {
-    libaryTarget: "var",
+    libraryTarget: "var",
     path: path.join(defaults.context, "build/client"),
     publicPath: "/",
   }),

--- a/example/webpack2/webpack.config.defaults.js
+++ b/example/webpack2/webpack.config.defaults.js
@@ -8,15 +8,14 @@ module.exports = {
 
   module: {
     loaders: [
-      { test: /\.css$/, loader: "style" },
-      { test: /\.css$/, loader: "css", query: { localIdentName: "[name]-[local]--[hash:base64:5]" } },
-      { test: /\.eot$/, loader: "file" },
-      { test: /\.js$/, loader: "babel", query: { cacheDirectory: true }, exclude: /node_modules/ },
-      { test: /\.json$/, loader: "json" },
-      { test: /\.(png|jpg)$/, loader: "url", query: { limit: 8192 } }, // Inline base64 URLs for <= 8K images
-      { test: /\.svg$/, loader: "url", query: { mimetype: "image/svg+xml" } },
-      { test: /\.ttf$/, loader: "url", query: { mimetype: "application/octet-stream" } },
-      { test: /\.(woff|woff2)$/, loader: "url", query: { mimetype: "application/font-woff" } },
+      { test: /\.css$/, loader: "style-loader" },
+      { test: /\.css$/, loader: "css-loader", options: { localIdentName: "[name]-[local]--[hash:base64:5]" } },
+      { test: /\.eot$/, loader: "file-loader" },
+      { test: /\.js$/, loader: "babel-loader", options: { cacheDirectory: true }, exclude: /node_modules/ },
+      { test: /\.(png|jpg)$/, loader: "url-loader", options: { limit: 8192 } }, // Inline base64 URLs for <= 8K images
+      { test: /\.svg$/, loader: "url-loader", options: { mimetype: "image/svg+xml" } },
+      { test: /\.ttf$/, loader: "url-loader", options: { mimetype: "application/octet-stream" } },
+      { test: /\.(woff|woff2)$/, loader: "url-loader", options: { mimetype: "application/font-woff" } },
     ],
   },
 

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "coverage": "npm test && nyc report --reporter=text-lcov | coveralls",
     "postversion": "npm run version:amend && git push origin master --tags && npm publish",
     "test": "cross-env NODE_ENV=test nyc mocha",
+    "test:watch": "cross-env NODE_ENV=test mocha --watch",
     "version": "npm run changelog",
     "version:amend": "git commit --amend -m \"Release v${npm_package_version}\""
   },

--- a/src/installer.js
+++ b/src/installer.js
@@ -9,6 +9,17 @@ var PEERS = /UNMET PEER DEPENDENCY ([a-z\-0-9\.]+)@(.+)/gm;
 var defaultOptions = { dev: false, peerDependencies: true };
 var erroneous = [];
 
+function normalizeBabelPlugin(plugin, prefix) {
+  // Babel plugins can be configured as [plugin, options]
+  if (Array.isArray(plugin)) {
+    plugin = plugin[0];
+  }
+  if (plugin.indexOf(prefix) === 0) {
+    return plugin;
+  }
+  return prefix + plugin;
+}
+
 module.exports.check = function(request) {
   if (!request) {
     return;
@@ -99,13 +110,13 @@ module.exports.checkBabel = function checkBabel() {
 
   // Accumulate babel-core (required for babel-loader)+ all dependencies
   var deps = ["babel-core"].concat(options.plugins.map(function(plugin) {
-    return "babel-plugin-" + plugin;
+    return normalizeBabelPlugin(plugin, "babel-plugin-");
   })).concat(options.presets.map(function(preset) {
-    return "babel-preset-" + preset;
+    return normalizeBabelPlugin(preset, "babel-preset-");
   })).concat(options.env.development.plugins.map(function(plugin) {
-    return "babel-plugin-" + plugin;
+    return normalizeBabelPlugin(plugin, "babel-plugin-");
   })).concat(options.env.development.presets.map(function(preset) {
-    return "babel-preset-" + preset;
+    return normalizeBabelPlugin(preset, "babel-preset-");
   }));
 
   // Check for missing dependencies

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,0 +1,12 @@
+/**
+ * Ensure loaders end with `-loader` (e.g. `babel` => `babel-loader`)
+ * Also force Webpack2's duplication of `-loader` to a single occurrence
+ */
+module.exports.normalizeLoader = function(loader) {
+  return loader             // e.g. react-hot-loader/webpack
+         .split("/")        // ["react-hot-loader", "webpack"]
+         .shift()           // "react-hot-loader"
+         .split("-loader")  // ["react-hot", ""]
+         .shift()           // "react-hot"
+         .concat("-loader") // "react-hot-loader"
+}

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -149,7 +149,7 @@ describe("installer", function() {
 
     context("when .babelrc exists", function() {
       beforeEach(function() {
-        process.chdir(path.join(process.cwd(), "example/webpack1"));
+        process.chdir(path.join(process.cwd(), "example/webpack2"));
 
         this.check = expect.spyOn(installer, "check").andCall(function(dep) {
           return dep;

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -1,0 +1,15 @@
+var expect = require("expect");
+
+var utils = require("../src/utils");
+
+describe("utils", function() {
+  describe(".normalizeLoader", function() {
+    it("should convert `babel` to `babel-loader`", function() {
+      expect(utils.normalizeLoader("babel")).toBe("babel-loader");
+    });
+
+    it("should convert `react-hot-loader/webpack` to `react-hot-loader`", function() {
+      expect(utils.normalizeLoader("react-hot-loader/webpack")).toBe("react-hot-loader");
+    });
+  })
+})


### PR DESCRIPTION
I have no idea if this is the *correct* approach for this, as I've not personally ever made use of `NpmInstallPlugin` for loaders before and I don't really know what Webpack is doing under there, but it fixes #91 for me locally when I have `resolveLoader` config which allows webpack to resolve html-webpack-plugin's loader.

If this does the trick, I can update the failing tests to test the new implementation.