### PR TITLE
Use after-resolvers to hook into resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "expect": "^1.14.0",
     "mocha": "^3.0.0",
     "nyc": "^8.1.0",
-    "webpack": "^1.13.0"
+    "webpack": "^2.2.0"
   },
   "peerDependencies": {
     "webpack": "^1.12.0 || ^2.1.0-beta.0 || ^2.1.0"

--- a/src/plugin.js
+++ b/src/plugin.js
@@ -46,11 +46,13 @@ NpmInstallPlugin.prototype.apply = function(compiler) {
     compiler.options.externals.unshift(this.resolveExternal.bind(this));
   }
 
-  // Install loaders on demand
-  compiler.resolvers.loader.plugin("module", this.resolveLoader.bind(this));
+  compiler.plugin("after-resolvers", function(compiler) {
+    // Install loaders on demand
+    compiler.resolvers.loader.plugin("module", this.resolveLoader.bind(this));
 
-  // Install project dependencies on demand
-  compiler.resolvers.normal.plugin("module", this.resolveModule.bind(this));
+    // Install project dependencies on demand
+    compiler.resolvers.normal.plugin("module", this.resolveModule.bind(this));
+  }.bind(this))
 };
 
 NpmInstallPlugin.prototype.install = function(result) {


### PR DESCRIPTION
Resolvers are created later in the process in Webpack 2 - they're `null` if you try to access them in `apply()`.

This makes the plugin work for me while testing the Webpack 2 version of nwb.

- [x] Fix tests

This should also fix #88 