### PR TITLE
docs(readme): updates for JSF maintainers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,39 +1,18 @@
-# npm-install-webpack-plugin
+[![npm][npm]][npm-url]
+[![deps][deps]][deps-url]
+[![test][test]][test-url]
+[![coverage][cover]][cover-url]
+[![chat][chat]][chat-url]
 
-> Speed up development by **automatically installing & saving dependencies** with Webpack.
->
-> [![npm-install-webpack-plugin mp4](https://cloud.githubusercontent.com/assets/15182/12540538/6a4e8f1a-c2d0-11e5-97ee-4ddaf6892645.gif)](https://dl.dropboxusercontent.com/u/55764/npm-install-webpack-plugin.mp4)
-
-## Features
-
-- [x] Works with both Webpack `^v1.12.0` and `^2.1.0-beta.0`.
-- [x] Auto-installs `.babelrc` plugins & presets.
-- [x] Supports both ES5 & ES6 Modules.
-  (e.g. `require`, `import`)
-- [x] Supports Namespaced packages.
-  (e.g. `@cycle/dom`)
-- [x] Supports Dot-delimited packages.
-  (e.g. `lodash.capitalize`)
-- [x] Supports CSS imports.
-  (e.g. `@import "~bootstrap"`)
-- [x] Supports Webpack loaders.
-  (e.g. `babel-loader`, `file-loader`, etc.)
-- [x] Supports inline Webpack loaders.
-  (e.g. `require("bundle?lazy!./App"`)
-- [x] Auto-installs missing `peerDependencies`.
-  (e.g. `@cycle/core` will automatically install `rx@*`)
-- [x] Supports Webpack's `resolve.alias` & `resolve.root` configuration.
-  (e.g. `require("react")` can alias to `react-lite`)
-
-[![travis build](https://img.shields.io/travis/ericclemmons/npm-install-webpack-plugin.svg)](https://travis-ci.org/ericclemmons/npm-install-webpack-plugin)
-[![Coverage Status](https://coveralls.io/repos/ericclemmons/npm-install-webpack-plugin/badge.svg?branch=master&service=github)](https://coveralls.io/github/ericclemmons/npm-install-webpack-plugin?branch=master)
-[![version](https://img.shields.io/npm/v/npm-install-webpack-plugin.svg)](http://npm.im/npm-install-webpack-plugin)
-[![downloads](https://img.shields.io/npm/dm/npm-install-webpack-plugin.svg)](http://npm-stat.com/charts.html?package=npm-install-webpack-plugin)
-[![MIT License](https://img.shields.io/npm/l/npm-install-webpack-plugin.svg)](http://opensource.org/licenses/MIT)
-
-- - -
-
-### Why?
+<div align="center">
+  <!-- replace with accurate logo e.g from https://worldvectorlogo.com/ -->
+  <a href="https://github.com/webpack/webpack">
+    <img width="200" height="200" vspace="" hspace="25"
+      src="https://cdn.rawgit.com/webpack/media/e7485eb2/logo/icon.svg">
+  </a>
+  <h1>NPM Install Webpack Plugin</h1>
+  <p>Speed up development by <b>automatically installing & saving dependencies</b> with Webpack.<p>
+</div>
 
 It sucks to <kbd>Ctrl-C</kbd> your
 build script & server just to install
@@ -42,13 +21,13 @@ a dependency you didn't know you needed until now.
 Instead, use `require` or `import` how you normally would and `npm install`
 will happen **automatically to install & save missing dependencies** while you work!
 
-### Installation
+<h2 align="center">Install</h2>
 
-```shell
+```bash
 $ npm install --save-dev npm-install-webpack-plugin
 ```
 
-### Usage
+<h2 align="center">Usage</h2>
 
 In your `webpack.config.js`:
 
@@ -89,7 +68,64 @@ plugins: [
 ],
 ```
 
+<h2 align="center">Demo</h2>
 
-### License
+[![npm-install-webpack-plugin mp4](https://cloud.githubusercontent.com/assets/15182/12540538/6a4e8f1a-c2d0-11e5-97ee-4ddaf6892645.gif)](https://dl.dropboxusercontent.com/u/55764/npm-install-webpack-plugin.mp4)
 
-> MIT License 2016 © Eric Clemmons
+<h2 align="center">Features</h2>
+
+- [x] Works with both Webpack `^v1.12.0` and `^2.1.0-beta.0`.
+- [x] Auto-installs `.babelrc` plugins & presets.
+- [x] Supports both ES5 & ES6 Modules.
+  (e.g. `require`, `import`)
+- [x] Supports Namespaced packages.
+  (e.g. `@cycle/dom`)
+- [x] Supports Dot-delimited packages.
+  (e.g. `lodash.capitalize`)
+- [x] Supports CSS imports.
+  (e.g. `@import "~bootstrap"`)
+- [x] Supports Webpack loaders.
+  (e.g. `babel-loader`, `file-loader`, etc.)
+- [x] Supports inline Webpack loaders.
+  (e.g. `require("bundle?lazy!./App"`)
+- [x] Auto-installs missing `peerDependencies`.
+  (e.g. `@cycle/core` will automatically install `rx@*`)
+- [x] Supports Webpack's `resolve.alias` & `resolve.root` configuration.
+  (e.g. `require("react")` can alias to `react-lite`)
+
+<h2 align="center">Maintainers</h2>
+
+<table>
+  <tbody>
+    <tr>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars2.githubusercontent.com/u/15182?v=3&s=150">
+        </br>
+        <a href="https://github.com/ericclemmons">Eric Clemmons</a>
+      </td>
+      <td align="center">
+        <img width="150" height="150"
+        src="https://avatars3.githubusercontent.com/u/226692?v=3&s=150">
+        </br>
+        <a href="https://github.com/insin">Jonny Buchanan</a>
+      </td>
+    </tr>
+  <tbody>
+</table>
+
+
+[npm]: https://img.shields.io/npm/v/npm-install-webpack-plugin.svg
+[npm-url]: https://npmjs.com/package/npm-install-webpack-plugin
+
+[deps]: https://david-dm.org/webpack-contrib/npm-install-webpack-plugin.svg
+[deps-url]: https://david-dm.org/webpack-contrib/npm-install-webpack-plugin
+
+[chat]: https://img.shields.io/badge/gitter-webpack%2Fwebpack-brightgreen.svg
+[chat-url]: https://gitter.im/webpack/webpack
+
+[test]: https://travis-ci.org/webpack-contrib/npm-install-webpack-plugin.svg?branch=master
+[test-url]: https://travis-ci.org/webpack-contrib/npm-install-webpack-plugin
+
+[cover]: https://codecov.io/gh/webpack-contrib/npm-install-webpack-plugin/branch/master/graph/badge.svg
+[cover-url]: https://codecov.io/gh/webpack-contrib/npm-install-webpack-plugin

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "changelog": "npm run changelog:generate && npm run changelog:add",
     "changelog:add": "git add CHANGELOG.md",
     "changelog:generate": "github_changelog_generator --future-release $npm_package_version",
-    "coverage": "npm test && nyc report --reporter=text-lcov | coveralls",
+    "coverage": "npm test && nyc report --reporter=lcov > coverage/coverage.lcov && codecov",
     "postversion": "npm run version:amend && git push origin master --tags && npm publish",
     "test": "cross-env NODE_ENV=test nyc mocha",
     "test:watch": "cross-env NODE_ENV=test mocha --watch",
@@ -42,7 +42,7 @@
     "resolve": "^1.2.0"
   },
   "devDependencies": {
-    "coveralls": "^2.11.8",
+    "codecov": "^1.0.1",
     "cross-env": "^3.1.4",
     "expect": "^1.14.0",
     "mocha": "^3.0.0",


### PR DESCRIPTION
- Updates `README.md` to cover both the Standards effort and the JSF Maintainers effort
- Changes coverage to `webpack-contrib` codecov.io
- Repo token added to Travis env vars
- Updates badges to reflect move to `webpack-contrib`