### PR TITLE
feat: specify install (`node_modules`) directory (`options.cwd`)

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -146,7 +146,8 @@ module.exports.install = function install(deps, options) {
 
   // Ignore input, capture output, show errors
   var output = spawn.sync("npm", args, {
-    stdio: ["ignore", "pipe", "inherit"]
+    stdio: ["ignore", "pipe", "inherit"],
+    cwd: options.cwd || process.cwd()
   });
 
   if (output.status) {

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -210,6 +210,21 @@ describe("installer", function() {
         });
       });
 
+      context("with a specified cwd", function() {
+        it("should install it in specified cwd", function() {
+          var cwd = {
+            cwd: "foo"
+          };
+          var result = installer.install("foo", cwd);
+
+          expect(this.sync).toHaveBeenCalled();
+          expect(this.sync.calls.length).toEqual(1);
+          expect(this.sync.calls[0].arguments[0]).toEqual("npm");
+          expect(this.sync.calls[0].arguments[1]).toEqual(["install", "foo", "--save"]);
+          expect(this.sync.calls[0].arguments[2]).toInclude(cwd);
+        });
+      });
+
       context("with dev set to true", function() {
         it("should install it with --save-dev", function() {
           var result = installer.install("foo", {


### PR DESCRIPTION
This plugin is awesome, thank you; however, I'd like to specify where I want the modules to be installed (for me it's in the build folder for node projects).

I've added a cwd option to the options object that defaults to `process.cwd()` so I can specify where I want the plugin to stick the modules folder.

I hope that's ok, and thanks for the great work.