### PR TITLE
feat: add `yarn` integration

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -140,14 +140,30 @@ module.exports.install = function install(deps, options) {
     return;
   }
 
-  var args = ["install"].concat(deps).filter(Boolean);
+  var args;
+  var client;
+  var quietOptions;  
+  var save;
+  if (options.yarn) {
+    args = ['add'];
+    client = 'yarn';
+    save = options.dev ? "--dev" : null;
+    quietOptions = ["--silent"];
+  } else {
+    args = ['install'];
+    client = options.npm;
+    save = options.dev ? "--save-dev" : "--save";
+    quietOptions = ["--silent", "--no-progress"];
+  }
 
-  if (module.exports.packageExists()) {
-    args.push(options.dev ? "--save-dev" : "--save");
+  args = args.concat(deps).filter(Boolean);
+
+  if (save && module.exports.packageExists()) {
+    args.push(save);
   }
 
   if (options.quiet) {
-    args.push("--silent", "--no-progress");
+    args = args.concat(quietOptions);
   }
 
   deps.forEach(function(dep) {
@@ -155,7 +171,7 @@ module.exports.install = function install(deps, options) {
   });
 
   // Ignore input, capture output, show errors
-  var output = spawn.sync(options.npm, args, {
+  var output = spawn.sync(client, args, {
     stdio: ["ignore", "pipe", "inherit"]
   });
 

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -198,106 +198,223 @@ describe("installer", function() {
       });
     });
 
-    context("given a dependency", function() {
-      context("with no options", function() {
-        it("should install it with --save", function() {
-          var result = installer.install("foo");
-
-          expect(this.sync).toHaveBeenCalled();
-          expect(this.sync.calls.length).toEqual(1);
-          expect(this.sync.calls[0].arguments[0]).toEqual("npm");
-          expect(this.sync.calls[0].arguments[1]).toEqual(["install", "foo", "--save"]);
-        });
-      });
-
-      context("with dev set to true", function() {
-        it("should install it with --save-dev", function() {
-          var result = installer.install("foo", {
-            dev: true,
-          });
-
-          expect(this.sync).toHaveBeenCalled();
-          expect(this.sync.calls.length).toEqual(1);
-          expect(this.sync.calls[0].arguments[0]).toEqual("npm");
-          expect(this.sync.calls[0].arguments[1]).toEqual(["install", "foo", "--save-dev"]);
-        });
-      });
-
-      context("without a package.json present", function() {
-        beforeEach(function() {
-          expect.spyOn(installer, "packageExists").andReturn(false);
-        });
-
-        afterEach(function() {
-          expect.restoreSpies();
-        });
-
-        it("should install without --save", function() {
-          var result = installer.install("foo");
-          expect(this.sync).toHaveBeenCalled();
-          expect(this.sync.calls.length).toEqual(1);
-          expect(this.sync.calls[0].arguments[0]).toEqual("npm");
-          expect(this.sync.calls[0].arguments[1]).toEqual(["install", "foo"]);
-        });
-      });
-
-      context("with quiet set to true", function() {
-        it("should install it with --silent --noprogress", function() {
-          var result = installer.install("foo", {
-            quiet: true,
-          });
-
-          expect(this.sync).toHaveBeenCalled();
-          expect(this.sync.calls.length).toEqual(1);
-          expect(this.sync.calls[0].arguments[0]).toEqual("npm");
-          expect(this.sync.calls[0].arguments[1]).toEqual(
-            ["install", "foo", "--save", "--silent", "--no-progress"]
-          );
-        });
-      });
-
-      context("with missing peerDependencies", function() {
-        beforeEach(function() {
-          this.sync.andCall(function(bin, args) {
-            var dep = args[1];
-
-            if (dep === "redbox-react") {
-              return {
-                stdout: new Buffer([
-                  "/test",
-                  "├── redbox-react@1.2.3",
-                  "└── UNMET PEER DEPENDENCY react@>=0.13.2 || ^0.14.0-rc1 || ^15.0.0-rc",
-                ].join("\n")),
-              };
-            }
-
-            return { stdout: null };
-          });
-        });
-
-        context("given no options", function() {
-          it("should install peerDependencies", function() {
-            var result = installer.install("redbox-react");
-
-            expect(this.sync.calls.length).toEqual(2);
-            expect(this.sync.calls[0].arguments[1]).toEqual(["install", "redbox-react", "--save"]);
-
-            // Ignore ranges, let NPM pick
-            expect(this.sync.calls[1].arguments[1]).toEqual(["install", "react", "--save"]);
-          });
-        });
-
-        context("given peerDependencies set to false", function() {
-          it("should not install peerDependencies", function() {
-            var result = installer.install("redbox-react", {
-              peerDependencies: false,
+    context('when using yarn', function() {
+      context("given a dependency", function() {
+        context("with no options", function() {
+          it("should install it with --save", function() {
+            var result = installer.install("foo", { 
+              yarn: true,
             });
 
+            expect(this.sync).toHaveBeenCalled();
             expect(this.sync.calls.length).toEqual(1);
-            expect(this.sync.calls[0].arguments[1]).toEqual(["install", "redbox-react", "--save"]);
+            expect(this.sync.calls[0].arguments[0]).toEqual("yarn");
+            expect(this.sync.calls[0].arguments[1]).toEqual(["add", "foo"]);
+          });
+        });
+
+        context("with dev set to true", function() {
+          it("should install it with --dev", function() {
+            var result = installer.install("foo", {
+              dev: true,
+              yarn: true,
+            });
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.calls.length).toEqual(1);
+            expect(this.sync.calls[0].arguments[0]).toEqual("yarn");
+            expect(this.sync.calls[0].arguments[1]).toEqual(["add", "foo", "--dev"]);
+          });
+        });
+
+        context("without a package.json present", function() {
+          beforeEach(function() {
+            expect.spyOn(installer, "packageExists").andReturn(false);
+          });
+
+          afterEach(function() {
+            expect.restoreSpies();
+          });
+
+          it("should install without options", function() {
+            var result = installer.install("foo", {
+              yarn: true,
+            });
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.calls.length).toEqual(1);
+            expect(this.sync.calls[0].arguments[0]).toEqual("yarn");
+            expect(this.sync.calls[0].arguments[1]).toEqual(["add", "foo"]);
+          });
+        });
+
+        context("with quiet set to true", function() {
+          it("should install it with --silent --noprogress", function() {
+            var result = installer.install("foo", {
+              quiet: true,
+              yarn: true,
+            });
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.calls.length).toEqual(1);
+            expect(this.sync.calls[0].arguments[0]).toEqual("yarn");
+            expect(this.sync.calls[0].arguments[1]).toEqual(
+              ["add", "foo", "--silent"]
+            );
+          });
+        });
+
+        context("with missing peerDependencies", function() {
+          beforeEach(function() {
+            this.sync.andCall(function(bin, args) {
+              var dep = args[1];
+
+              if (dep === "redbox-react") {
+                return {
+                  stdout: new Buffer([
+                    "/test",
+                    "├── redbox-react@1.2.3",
+                    "└── UNMET PEER DEPENDENCY react@>=0.13.2 || ^0.14.0-rc1 || ^15.0.0-rc",
+                  ].join("\n")),
+                };
+              }
+
+              return { stdout: null };
+            });
+          });
+
+          context("given no options", function() {
+            it("should install peerDependencies", function() {
+              var result = installer.install("redbox-react", {
+                yarn: true,
+              });
+
+              expect(this.sync.calls.length).toEqual(2);
+              expect(this.sync.calls[0].arguments[1]).toEqual(["add", "redbox-react"]);
+
+              // Ignore ranges, let NPM pick
+              expect(this.sync.calls[1].arguments[1]).toEqual(["add", "react"]);
+            });
+          });
+
+          context("given peerDependencies set to false", function() {
+            it("should not install peerDependencies", function() {
+              var result = installer.install("redbox-react", {
+                peerDependencies: false,
+                yarn: true,
+              });
+
+              expect(this.sync.calls.length).toEqual(1);
+              expect(this.sync.calls[0].arguments[1]).toEqual(["add", "redbox-react"]);
+            });
           });
         });
       });
     });
+
+    context('when using npm', function() {
+      context("given a dependency", function() {
+        context("with no options", function() {
+          it("should install it with --save", function() {
+            var result = installer.install("foo");
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.calls.length).toEqual(1);
+            expect(this.sync.calls[0].arguments[0]).toEqual("npm");
+            expect(this.sync.calls[0].arguments[1]).toEqual(["install", "foo", "--save"]);
+          });
+        });
+
+        context("with dev set to true", function() {
+          it("should install it with --save-dev", function() {
+            var result = installer.install("foo", {
+              dev: true,
+            });
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.calls.length).toEqual(1);
+            expect(this.sync.calls[0].arguments[0]).toEqual("npm");
+            expect(this.sync.calls[0].arguments[1]).toEqual(["install", "foo", "--save-dev"]);
+          });
+        });
+
+        context("without a package.json present", function() {
+          beforeEach(function() {
+            expect.spyOn(installer, "packageExists").andReturn(false);
+          });
+
+          afterEach(function() {
+            expect.restoreSpies();
+          });
+
+          it("should install without --save", function() {
+            var result = installer.install("foo");
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.calls.length).toEqual(1);
+            expect(this.sync.calls[0].arguments[0]).toEqual("npm");
+            expect(this.sync.calls[0].arguments[1]).toEqual(["install", "foo"]);
+          });
+        });
+
+        context("with quiet set to true", function() {
+          it("should install it with --silent --noprogress", function() {
+            var result = installer.install("foo", {
+              quiet: true,
+            });
+
+            expect(this.sync).toHaveBeenCalled();
+            expect(this.sync.calls.length).toEqual(1);
+            expect(this.sync.calls[0].arguments[0]).toEqual("npm");
+            expect(this.sync.calls[0].arguments[1]).toEqual(
+              ["install", "foo", "--save", "--silent", "--no-progress"]
+            );
+          });
+        });
+
+        context("with missing peerDependencies", function() {
+          beforeEach(function() {
+            this.sync.andCall(function(bin, args) {
+              var dep = args[1];
+
+              if (dep === "redbox-react") {
+                return {
+                  stdout: new Buffer([
+                    "/test",
+                    "├── redbox-react@1.2.3",
+                    "└── UNMET PEER DEPENDENCY react@>=0.13.2 || ^0.14.0-rc1 || ^15.0.0-rc",
+                  ].join("\n")),
+                };
+              }
+
+              return { stdout: null };
+            });
+          });
+
+          context("given no options", function() {
+            it("should install peerDependencies", function() {
+              var result = installer.install("redbox-react");
+
+              expect(this.sync.calls.length).toEqual(2);
+              expect(this.sync.calls[0].arguments[1]).toEqual(["install", "redbox-react", "--save"]);
+
+              // Ignore ranges, let NPM pick
+              expect(this.sync.calls[1].arguments[1]).toEqual(["install", "react", "--save"]);
+            });
+          });
+
+          context("given peerDependencies set to false", function() {
+            it("should not install peerDependencies", function() {
+              var result = installer.install("redbox-react", {
+                peerDependencies: false,
+              });
+
+              expect(this.sync.calls.length).toEqual(1);
+              expect(this.sync.calls[0].arguments[1]).toEqual(["install", "redbox-react", "--save"]);
+            });
+          });
+        });
+      });
+    });
+
+    
   });
 });


### PR DESCRIPTION
I've taken a stab at adding yarn as an option. I wanted to make it very explicit what the state of the command's config should be when `yarn` vs `npm`, but am open to a different way of discerning between the two.

I also mirrored the tests that already existed for `npm`, but for `yarn`. Let me know if I missed anything there!

As requested in #76, I exposed yarn by adding a `yarn` option. When true, it goes down the yarn path, otherwise, uses the same npm path. So an example usage would be:

```javascript
new NpmInstallPlugin({
  yarn: true
});
```

This should resolve #76.