### PR TITLE
docs(README): remove broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ plugins: [
 
 <h2 align="center">Demo</h2>
 
-[![npm-install-webpack-plugin mp4](https://cloud.githubusercontent.com/assets/15182/12540538/6a4e8f1a-c2d0-11e5-97ee-4ddaf6892645.gif)](https://dl.dropboxusercontent.com/u/55764/npm-install-webpack-plugin.mp4)
+![npm-install-webpack-plugin demo](https://cloud.githubusercontent.com/assets/15182/12540538/6a4e8f1a-c2d0-11e5-97ee-4ddaf6892645.gif)
 
 <h2 align="center">Features</h2>
 


### PR DESCRIPTION
This link was causing builds to fail on webpack.js.org. You probably want to resolve whatever the core issue is and add it back but this a temporary fix for now.