### PR TITLE
Webpack 4 (only) compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,6 @@
     "webpack": "^3.0.0"
   },
   "peerDependencies": {
-    "webpack": "^1.0.0 || ^2.0.0 || >= 3.0.0-rc.0 || ^3.0.0"
+    "webpack": "^4.0.0"
   }
 }


### PR DESCRIPTION
I'm wondering if the note about `Compiler.options` in the Webpack 4 release notes only applies to loaders.

PR for #122 

Basic functionality working for me in the Webpack 4 version of nwb:

![conemu64_2018-03-12_23-42-16](https://user-images.githubusercontent.com/226692/37286889-09463ada-264f-11e8-8089-59fce4bc0416.png)

