### PR TITLE
chore: fixed the pkg names

### DIFF
--- a/src/installer.js
+++ b/src/installer.js
@@ -99,14 +99,14 @@ module.exports.checkBabel = function checkBabel() {
   }, options.env.development);
 
   // Accumulate babel-core (required for babel-loader)+ all dependencies
-  var deps = ["babel-core"].concat(options.plugins.map(function(plugin) {
+  var deps = ["@babel/core"].concat(options.plugins.map(function(plugin) {
     return normalizeBabelPlugin(plugin, "babel-plugin-");
   })).concat(options.presets.map(function(preset) {
-    return normalizeBabelPlugin(preset, "babel-preset-");
+    return normalizeBabelPlugin(preset, "@babel/preset-");
   })).concat(options.env.development.plugins.map(function(plugin) {
     return normalizeBabelPlugin(plugin, "babel-plugin-");
   })).concat(options.env.development.presets.map(function(preset) {
-    return normalizeBabelPlugin(preset, "babel-preset-");
+    return normalizeBabelPlugin(preset, "@babel/preset-");
   }));
 
   // Check for missing dependencies

--- a/test/installer.test.js
+++ b/test/installer.test.js
@@ -124,12 +124,12 @@ describe("installer", function() {
         expect(this.check).toHaveBeenCalled();
         expect(this.check.calls.length).toEqual(6);
         expect(checked).toEqual([
-          'babel-core',
+          '@babel/core',
           'babel-plugin-react-html-attrs',
-          'babel-preset-react',
-          'babel-preset-es2015',
-          'babel-preset-stage-0',
-          'babel-preset-react-hmre'
+          '@babel/preset-react',
+          '@babel/preset-es2015',
+          '@babel/preset-stage-0',
+          '@babel/preset-react-hmre'
         ]);
       });
 
@@ -140,12 +140,12 @@ describe("installer", function() {
         expect(this.install.calls.length).toEqual(1);
         expect(this.install.calls[0].arguments).toEqual([
           [
-            'babel-core',
+            '@babel/core',
             'babel-plugin-react-html-attrs',
-            'babel-preset-react',
-            'babel-preset-es2015',
-            'babel-preset-stage-0',
-            'babel-preset-react-hmre'
+            '@babel/preset-react',
+            '@babel/preset-es2015',
+            '@babel/preset-stage-0',
+            '@babel/preset-react-hmre'
           ],
         ]);
       });


### PR DESCRIPTION
Currently, the default `babel` packages name used are outdated and not supported anymore. Fixed them by using the new names

> follow up of #130 